### PR TITLE
Allow extraction of all methods in entire session

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,8 +18,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
-          - '1.9'
+          - '1.6'
+          - '1'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -2,3 +2,7 @@
 BasicBlockRewriter = "53fb9386-eb44-4e91-947a-bb3af0aa8558"
 MethodAnalysis = "85b6ec6f-f7df-4429-9514-a64bcd9ee824"
 PyPlot = "d330b81b-6aea-500a-939a-2ce795aea3ee"
+
+[compat]
+MethodAnalysis = "0.4.6"
+PyPlot = "2"


### PR DESCRIPTION
This only affects the `fragment_counter` example. 