### PR TITLE
GlobalRef lookup, constant & LNN extraction

### DIFF
--- a/examples/fragment_counter.jl
+++ b/examples/fragment_counter.jl
@@ -30,7 +30,9 @@ collect_methods(top::Module; kwargs...) = collect_methods((top,); kwargs...)
 
 function catalog_fragments!(fragdict, m::Method)
     try
-        for frag in fragments(m)
+        for item in fragments(m)
+            isa(item, Pair{FragmentData,Fragment}) || continue
+            _, frag = item
             fragdict[frag] = get(fragdict, frag, 0) + 1
         end
     catch err
@@ -44,7 +46,7 @@ function catalog_fragments!(fragdict, m::Method)
 end
 
 meths = collect_methods(; exclude=child_modules(Core))
-fragdict = Dict{Vector{Any},Int}()
+fragdict = Dict{Fragment,Int}()
 for m in meths
     catalog_fragments!(fragdict, m)
 end

--- a/examples/fragment_counter.jl
+++ b/examples/fragment_counter.jl
@@ -49,6 +49,11 @@ for m in meths
     catalog_fragments!(fragdict, m)
 end
 
+function trimmax(bins, mx)
+    idx = searchsortedlast(bins, mx)
+    return bins[begin:min(idx+1, lastindex(bins))]
+end
+
 if lowercase(get(ENV, "CI", "false")) != "true"
     fig, axs = plt.subplots(1, 3, figsize=(8, 3))
     ax = axs[1]
@@ -67,10 +72,13 @@ if lowercase(get(ENV, "CI", "false")) != "true"
 
     ax = axs[3]
     kv = collect(fragdict)
-    ax.scatter(length.(first.(kv)), last.(kv))
+    x, y = length.(first.(kv)), last.(kv)
+    counts, xb, yb, img = ax.hist2d(x, y, bins=[trimmax(bins, maximum(x)), trimmax(bins, maximum(y))], norm=plt.matplotlib.colors.LogNorm())
+    ax.set_xscale("log")
     ax.set_yscale("log")
     ax.set_xlabel("# statements")
     ax.set_ylabel("# callers")
+    plt.colorbar(img; ax, label="Count")
 
     fig.tight_layout()
 end

--- a/src/BasicBlockRewriter.jl
+++ b/src/BasicBlockRewriter.jl
@@ -46,7 +46,8 @@ function rewrite_statement(stmt, rng, ssa, toslot)
         return out
     end
     if isa(stmt, GlobalRef)
-        return GlobalRef(rewrite_statement(stmt.mod, rng, ssa, toslot), rewrite_statement(stmt.name, rng, ssa, toslot))
+        # Do the lookup now (helps with uniquing)
+        return isdefined(stmt.mod, stmt.name) ? getfield(stmt.mod, stmt.name) : stmt
     end
     isa(stmt, SimpleVector) && return svec([rewrite_statement(stmt[i], rng, ssa, toslot) for i = 1:length(stmt)]...)
     # The remainder are not concretely typed.

--- a/src/BasicBlockRewriter.jl
+++ b/src/BasicBlockRewriter.jl
@@ -4,64 +4,82 @@ using Core: GotoNode, GotoIfNot, ReturnNode, SlotNumber, SSAValue, NewvarNode, S
 using Core: svec
 using Base: mapany
 
-export fragments
+export fragments, Fragment, FragmentData
 
 const emptyvec = Any[]
 
-function relocatable_fragment(stmts, ssa1::Integer)
-    toslot = Dict{Union{SlotNumber,SSAValue},SlotNumber}()
-    stmtso = Any[]
-    for (i, stmt) in enumerate(stmts)
-        if isa(stmt, GotoNode) || isa(stmt, GotoIfNot) || isa(stmt, ReturnNode)
-            break
-        end
-        push!(stmtso, rewrite_statement(stmt, ssa1:ssa1+length(stmts)-1, i+ssa1-1, toslot))
-    end
-    return stmtso
+struct LNNRef
+    id::Int
+end
+struct ConstRef
+    id::Int
 end
 
-function rewrite_statement(stmt, rng, ssa, toslot)
-    # Pass over some concretely-typed values that appear in code
-    # These are not exhaustive, but for the time being I'd rather hear about unhandled things
-    # than to have surprises.
+struct Fragment
+    code::Vector{Any}
+end
+Fragment() = Fragment([])
+Base.isempty(frag::Fragment) = isempty(frag.code)
+Base.length(frag::Fragment) = length(frag.code)
+Base.:(==)(frag1::Fragment, frag2::Fragment) = frag1.code == frag2.code
+const _frag_hash_seed_ = Int === Int64 ? 0xb2608230b093d1b4 : 0x441223d4
+Base.hash(frag::Fragment, h::UInt) = hash(frag.code, hash(_frag_hash_seed_, h))
+
+struct FragmentData
+    lnns::Vector{LineNumberNode}
+    consts::Vector{Any}
+end
+FragmentData() = FragmentData(LineNumberNode[], [])
+Base.isempty(fragdata::FragmentData) = isempty(fragdata.lnns) && isempty(fragdata.consts)
+
+function relocatable_fragment!(frags, stmts, ssa1::Integer)
+    toslot = Dict{Union{SlotNumber,SSAValue},SlotNumber}()
+    frag, fragdata = Fragment(), FragmentData()
+    for (i, stmt) in enumerate(stmts)
+        if isa(stmt, GotoNode) || isa(stmt, GotoIfNot) || isa(stmt, ReturnNode) || isa(stmt, NewvarNode) || stmt === nothing
+            if !isempty(frag)
+                push!(frags, fragdata => frag)
+                frag, fragdata = Fragment(), FragmentData()
+            end
+            push!(frags, stmt)
+        else
+            push!(frag.code, rewrite_statement(stmt, ssa1:ssa1+length(stmts)-1, i+ssa1-1, fragdata, toslot))
+        end
+    end
+    return frags
+end
+
+function rewrite_statement(@nospecialize(stmt), rng::AbstractUnitRange, ssa::Integer, fragdata::FragmentData, toslot::AbstractDict)
     stmt === nothing && return stmt
-    isa(stmt, Symbol) && return stmt
-    isa(stmt, String) && return stmt
-    isa(stmt, Char) && return stmt
-    isa(stmt, LineNumberNode) && return nothing   # FIXME
-    isa(stmt, Module) && return stmt
-    isa(stmt, UnionAll) && return stmt
-    isa(stmt, VersionNumber) && return stmt
-    isa(stmt, Regex) && return stmt
-    isa(stmt, Core.Box) && return stmt
+    if isa(stmt, LineNumberNode)
+        push!(fragdata.lnns, stmt)
+        return LNNRef(length(fragdata.lnns))
+    end
     # Handle some "nontrival" code elements
-    isa(stmt, NewvarNode) && return NewvarNode(rewrite_statement(stmt.slot, rng, ssa, toslot))
     isa(stmt, SlotNumber) && return get!(() -> SlotNumber(length(toslot)+1), toslot, stmt)
     if isa(stmt, SSAValue)
         id = stmt.id
         return id ∈ rng ? SSAValue(id - first(rng) + 1) : get!(() -> SlotNumber(length(toslot)+1), toslot, stmt)
     end
-    isa(stmt, QuoteNode) && return QuoteNode(rewrite_statement(stmt.value, rng, ssa, toslot))
+    isa(stmt, QuoteNode) && return QuoteNode(rewrite_statement(stmt.value, rng, ssa, fragdata, toslot))
     if isa(stmt, Expr)
         out = Expr(stmt.head)
-        out.args = mapany(arg -> rewrite_statement(arg, rng, ssa, toslot), stmt.args)
+        out.args = mapany(arg -> rewrite_statement(arg, rng, ssa, fragdata, toslot), stmt.args)
         return out
     end
+    isa(stmt, SimpleVector) && return svec([rewrite_statement(stmt[i], rng, ssa, fragdata, toslot) for i = 1:length(stmt)]...)
     if isa(stmt, GlobalRef)
-        # Do the lookup now (helps with uniquing)
+        # Where possible, do the lookup now (helps with uniquing)
         return isdefined(stmt.mod, stmt.name) ? getfield(stmt.mod, stmt.name) : stmt
     end
-    isa(stmt, SimpleVector) && return svec([rewrite_statement(stmt[i], rng, ssa, toslot) for i = 1:length(stmt)]...)
-    # The remainder are not concretely typed.
-    # Put these last to avoid slow subtyping as often as possible.
-    isa(stmt, Tuple) && return map(item -> rewrite_statement(item, rng, ssa, toslot), stmt)
-    # More passing-over (not concretely typed)
-    isa(stmt, Number) && return stmt
-    (isa(stmt, AbstractString) || isa(stmt, Base.CodeUnits)) && return stmt
-    (isa(stmt, DataType) || stmt === Union{}) && return stmt
-    (isa(stmt, Val) || isa(stmt, Enum)) && return stmt
+    isa(stmt, Core.Box) && return Core.Box(rewrite_statement(stmt.contents, rng, ssa, fragdata, toslot))
+    # Preserve types as hard-coded since they are fundamental and can lose specialization if passed as an argument
+    isa(stmt, UnionAll) && return stmt
+    (isa(stmt, DataType) || isa(stmt, Union) || stmt === Union{}) && return stmt
     isa(stmt, Function) && return stmt
-    error("unhandled statement ", stmt, " of type ", typeof(stmt))
+    # Values
+    push!(fragdata.consts, stmt)
+    return ConstRef(length(fragdata.consts))
 end
 
 function fragments(m::Method)
@@ -71,7 +89,11 @@ function fragments(m::Method)
     end
     src = Base.uncompressed_ast(m)
     cfg = Core.Compiler.compute_basic_blocks(src.code)
-    return Any[relocatable_fragment(src.code[rng.start:rng.stop], rng.start) for rng in map(bb->bb.stmts, cfg.blocks)]
+    frags = []
+    for rng in map(bb->bb.stmts, cfg.blocks)
+        relocatable_fragment!(frags, src.code[rng.start:rng.stop], rng.start)
+    end
+    return frags
 end
 
 end

--- a/src/BasicBlockRewriter.jl
+++ b/src/BasicBlockRewriter.jl
@@ -6,6 +6,8 @@ using Base: mapany
 
 export fragments
 
+const emptyvec = Any[]
+
 function relocatable_fragment(stmts, ssa1::Integer)
     toslot = Dict{Union{SlotNumber,SSAValue},SlotNumber}()
     stmtso = Any[]
@@ -65,7 +67,7 @@ end
 function fragments(m::Method)
     if isdefined(m, :generator) && m.generator isa Core.GeneratedFunctionStub
         @warn "skipping generated function $m"
-        return Any[]
+        return emptyvec
     end
     src = Base.uncompressed_ast(m)
     cfg = Core.Compiler.compute_basic_blocks(src.code)


### PR DESCRIPTION
This gives the package a bit more formal structure. It's easier to recover the original AST: fragments are interwoven with non-fragment statements. Constants are extracted in an attempt to increase reuse, although the impact seems to be almost unnoticeable. More helpful is looking up GlobalRefs, since `Base.string` and `LinearAlgebra.string` actually mean the same function.